### PR TITLE
docs: Clarify --mask is mask-out exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,14 @@ Name of archaic individual.  Must match column name.
 If not specified, taken as the first column of the
 genotype file (default output order for `generate_gt`).
 - __-r, --mask__
-Bed file of masked regions to **include** in the analysis.
-If not specified all sites are considered.
+Bed file of masked regions to **exclude** from the analysis.
+If not specified all sites are considered. There are some
+caveats where discordant homozygous SNPs still get considered
+even if they are within masked regions
+([more info](https://github.com/PrincetonUniversity/IBDmix/issues/10)).
+Additionally, IBDmix calls may occur around masked sites if there
+is a positive LOD score "leading into" a masked regions.
+
 - __-d, --LOD-threshold__
 Threshold value of log(odds) for emitting regions.
 Default: 3.0

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If not specified all sites are considered. There are some
 caveats where discordant homozygous SNPs still get considered
 even if they are within masked regions
 ([more info](https://github.com/PrincetonUniversity/IBDmix/issues/10)).
-Additionally, IBDmix calls may occur around masked sites if there
+Additionally, IBDmix calls may still include masked sites if there
 is a positive LOD score "leading into" a masked regions.
 
 - __-d, --LOD-threshold__


### PR DESCRIPTION
Additionally referenced github issue about homozygous discordant SNPs still being used, even if within a mask, and the possibility of IBDmix calls extending through a masked region.