### PR TITLE
test: Update acceptance_test.sh data URL

### DIFF
--- a/.github/actions/acceptance_test/acceptance_test.sh
+++ b/.github/actions/acceptance_test/acceptance_test.sh
@@ -14,7 +14,7 @@ fi
 
 echo "starting $test_type"
 
-url_base="http://tigress-web.princeton.edu/~tcomi/ibdmix_tests"
+url_base="http://tigress-web.princeton.edu/AKEY/ibdmix_tests"
 
 
 read_result() {

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,5 +1,5 @@
 name: AcceptanceTests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 # TODO: generate_gt, generate_gt with tabs, population with mask, all with mask
 # all with no mask, inclusive end and stats

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: UnitTests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:


### PR DESCRIPTION
- Using AKEY tigress-web URL rather than tcomi, since user-based tigress-web will likely be deprecated in ~6 months.

- This is a temporary fix since the projects based tigress-web might take 2-3 years to be deprecated.

- Also add workflow_dispatch to acceptance.yml and tests.yml