### PR TITLE
test: Access AcceptanceTest data from Zenodo

### DIFF
--- a/.github/actions/acceptance_test/acceptance_test.sh
+++ b/.github/actions/acceptance_test/acceptance_test.sh
@@ -6,15 +6,16 @@ test_type=$1
 
 ibdmix="src/ibdmix"
 generate_gt="src/generate_gt"
-# to work for local tests
+# to work for local tests use `ibdmix` and `generate_gt`
+# executables in IBDmix/build/src folder following README
 if [[ ! -f $ibdmix ]]; then
-    ibdmix="../../../release/src/ibdmix"
-    generate_gt="../../../release/src/generate_gt"
+    ibdmix="../../../build/src/ibdmix"
+    generate_gt="../../../build/src/generate_gt"
 fi
 
 echo "starting $test_type"
 
-url_base="http://tigress-web.princeton.edu/AKEY/ibdmix_tests"
+url_base="https://zenodo.org/records/15127123/files"
 
 
 read_result() {
@@ -81,7 +82,7 @@ run_ibd_all_no_mask() {
 run_ibd_extra() {
     $ibdmix \
         -g <(wget -qO - $1 | zcat) \
-        -s <(wget -qO - "$url_base/cell_data/samples/GWD.txt") \
+        -s <(wget -qO - "$url_base/cell_data_samples_GWD.txt") \
         $2 \
         --output >( cat )
 }
@@ -89,16 +90,16 @@ run_ibd_extra() {
 run_ibd_extra_mask() {
     $ibdmix \
         -g <(wget -qO - $1 | zcat) \
-        -s <(wget -qO - "$url_base/cell_data/samples/GWD.txt") \
+        -s <(wget -qO - "$url_base/cell_data_samples_GWD.txt") \
         $2 \
         -r <(wget -qO - $3) \
         --output >( cat )
 }
 
 if [[ $test_type == "gen_20" ]]; then
-    resultfile="$url_base/cell_data/outputs/genotype/altai_1kg_20.gz"
-    mod="$url_base/cell_data/mod_chr20.vcf.gz"
-    arch="$url_base/cell_data/altai_chr20.vcf.gz"
+    resultfile="$url_base/cell_data_outputs_genotype_altai_1kg_20.gz"
+    mod="$url_base/cell_data_mod_chr20.vcf.gz"
+    arch="$url_base/cell_data_altai_chr20.vcf.gz"
 
     cmp \
         <(read_result $resultfile) \
@@ -108,11 +109,11 @@ elif [[ $test_type == "populations" ]]; then
     for pop in ACB ASW BEB CDX CEU CHB CHS CLM ESN FIN GBR GIH GWD \
         IBS ITU JPT KHV LWK MSL MXL PEL PJL PUR STU TSI YRI ; do
         echo $pop
-        resultfile="$url_base/cell_data/outputs/ibd_raw/altai_1kg_${pop}_20.gz"
+        resultfile="$url_base/cell_data_outputs_ibd_raw_altai_1kg_${pop}_20.gz"
 
-        genotype="$url_base/cell_data/outputs/genotype/altai_1kg_20.gz"
-        sample="$url_base/cell_data/samples/${pop}.txt"
-        mask="$url_base/cell_data/masks/chr20.bed"
+        genotype="$url_base/cell_data_outputs_genotype_altai_1kg_20.gz"
+        sample="$url_base/cell_data_samples_${pop}.txt"
+        mask="$url_base/cell_data_masks_chr20.bed"
 
         cmp \
             <(read_result "$resultfile") \
@@ -124,79 +125,79 @@ elif [[ $test_type == "populations" ]]; then
         <(run_ibd_pop_long $genotype $sample $mask)
 
 elif [[ $test_type == "all_mask" ]]; then
-    resultfile="$url_base/cell_data/outputs/ibd_raw/all_with_mask.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_all_with_mask.gz"
 
-    genotype="$url_base/cell_data/outputs/genotype/altai_1kg_20.gz"
-    mask="$url_base/cell_data/masks/chr20.bed"
+    genotype="$url_base/cell_data_outputs_genotype_altai_1kg_20.gz"
+    mask="$url_base/cell_data_masks_chr20.bed"
 
     cmp \
         <(read_result "$resultfile") \
         <(run_ibd_all_mask $genotype $mask)
 
 elif [[ $test_type == "all_no_mask" ]]; then
-    resultfile="$url_base/cell_data/outputs/ibd_raw/all_no_mask.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_all_no_mask.gz"
 
-    genotype="$url_base/cell_data/outputs/genotype/altai_1kg_20.gz"
+    genotype="$url_base/cell_data_outputs_genotype_altai_1kg_20.gz"
 
     cmp \
         <(read_result "$resultfile") \
         <(run_ibd_all_no_mask $genotype)
 
 elif [[ $test_type == "extra" ]]; then
-    genotype="$url_base/cell_data/outputs/genotype/altai_1kg_20.gz"
-    mask="$url_base/cell_data/masks/chr20.bed"
+    genotype="$url_base/cell_data_outputs_genotype_altai_1kg_20.gz"
+    mask="$url_base/cell_data_masks_chr20.bed"
 
     echo "with tab"
-    resultfile="$url_base/terminal_tab/genotype.out.gz"
-    mod="$url_base/terminal_tab/mod_chr22.vcf.gz"
-    arch="$url_base/terminal_tab/AltNea_n10000.vcf.gz"
+    resultfile="$url_base/terminal_tab_genotype.out.gz"
+    mod="$url_base/terminal_tab_mod_chr22.vcf.gz"
+    arch="$url_base/terminal_tab_AltNea_n10000.vcf.gz"
     cmp \
         <(read_result $resultfile) \
         <(run_genotype_long $arch $mod)
 
     echo "more stats"
-    resultfile="$url_base/cell_data/outputs/ibd_raw/GWD_20_stats.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_GWD_20_stats.gz"
     cmp \
         <(read_result "$resultfile") \
         <(run_ibd_extra $genotype "--more-stats")
 
     echo "inclusive end"
-    resultfile="$url_base/cell_data/outputs/ibd_raw/GWD_20_inclusive.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_GWD_20_inclusive.gz"
     cmp \
         <(read_result "$resultfile") \
         <(run_ibd_extra $genotype "--inclusive-end")
 
     echo "with snps"
-    resultfile="$url_base/cell_data/outputs/ibd_raw/GWD_20_snps.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_GWD_20_snps.gz"
     cmp \
         <(read_result "$resultfile") \
         <(run_ibd_extra $genotype "--write-snps")
 
     echo "with lods"
-    resultfile="$url_base/cell_data/outputs/ibd_raw/GWD_20_lods.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_GWD_20_lods.gz"
     cmp \
         <(read_result "$resultfile") \
         <(run_ibd_extra $genotype "--write-snps --write-lods")
 
     echo "short args"
-    resultfile="$url_base/cell_data/outputs/ibd_raw/GWD_20_itw.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_GWD_20_itw.gz"
     cmp \
         <(read_result "$resultfile") \
         <(run_ibd_extra $genotype "-itw")
 
     echo "short args mask"
-    resultfile="$url_base/cell_data/outputs/ibd_raw/GWD_20_itw_mask.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_GWD_20_itw_mask.gz"
     cmp \
         <(read_result "$resultfile") \
         <(run_ibd_extra_mask $genotype "-itw" $mask)
 
     echo "short args mask string chroms"
-    resultfile="$url_base/cell_data/outputs/ibd_raw/GWD_20_itw_mask.gz"
+    resultfile="$url_base/cell_data_outputs_ibd_raw_GWD_20_itw_mask.gz"
     cmp \
         <(read_result "$resultfile" | awk 'BEGIN {OFS="\t"} NR>1{$2 = "chr" $2} {print $0}' | head) \
         <($ibdmix \
             -g <(wget -qO - $genotype | zcat | awk  'BEGIN {OFS="\t"} NR>1{$1 = "chr" $1} {print $0}') \
-            -s <(wget -qO - "$url_base/cell_data/samples/GWD.txt") \
+            -s <(wget -qO - "$url_base/cell_data_samples_GWD.txt") \
             -itw \
             -r <(wget -qO - $mask | awk  'BEGIN {OFS="\t"} {$1 = "chr" $1 ; print $0}') \
             --output >( head ) \


### PR DESCRIPTION
- Asked Zenodo support if this was ok use-case (they said ok)
- Created Zenodo project: https://zenodo.org/records/15127123
- Zenodo doesn't allow directories, so "flattened" the tree
- For example the .vcf.gz and .bed file here:

```
    ibdmix_tests
    ├── cell_data
    │   ├── altai_chr20.vcf.gz
    │   ├── masks
    │   │   └── chr20.bed
    ...
```

  Are now represented as "flattened" with the folder structure as part of the file name:

    cell_data_altai_chr20.vcf.gz
    cell_data_masks_chr20.bed

- Zenodo flattened file structure required changing "/" to "_" in wget paths of `acceptance_test.sh`

- Also changed path to exec's for local testing to match where `ibdmix` and `generate_gt` get generated when following the README directions